### PR TITLE
More config options for AllenNLPProcessor

### DIFF
--- a/forte_wrapper/allennlp/allennlp_processors.py
+++ b/forte_wrapper/allennlp/allennlp_processors.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import logging
 from typing import List, Dict
 
 from allennlp.predictors import Predictor
+
 from forte.common import ProcessorConfigError
 from forte.common.configuration import Config
 from forte.common.resources import Resources
@@ -36,13 +38,10 @@ __all__ = [
 # pylint: disable=line-too-long
 MODEL2URL = {
     'stanford': "https://storage.googleapis.com/allennlp-public-models/biaffine-dependency-parser-ptb-2020.04.06.tar.gz",
-    'srl': "https://storage.googleapis.com/allennlp-public-models/bert-base-srl-2020.11.19.tar.gz"
+    'srl': "https://storage.googleapis.com/allennlp-public-models/bert-base-srl-2020.11.19.tar.gz",
     # TODO: The UD model seems to be broken at this moment.
-    # 'universal': "https://storage.googleapis.com/allennlp-public-models/biaffine-dependency-parser-ud-2020.02.10.tar.gz",
+    'universal': "https://storage.googleapis.com/allennlp-public-models/biaffine-dependency-parser-ud-2020.02.10.tar.gz",
 }
-
-
-# pylint: enable=line-too-long
 
 
 class AllenNLPProcessor(PackProcessor):
@@ -50,16 +49,27 @@ class AllenNLPProcessor(PackProcessor):
     # pylint: disable=attribute-defined-outside-init,unused-argument
     def initialize(self, resources: Resources, configs: Config):
         super().initialize(resources, configs)
-
+        cuda_devices = itertools.cycle(configs['cuda_devices'])
         if configs.tag_formalism not in MODEL2URL:
             raise ProcessorConfigError('Incorrect value for tag_formalism')
         if configs.tag_formalism == 'stanford':
             self.predictor = {
-                'stanford': Predictor.from_path(MODEL2URL['stanford'])}
+                'stanford': Predictor.from_path(
+                    configs['stanford_url'],
+                    cuda_device=next(cuda_devices)
+                )
+            }
         if 'srl' in configs.processors:
             self.predictor = {
-                'stanford': Predictor.from_path(MODEL2URL['stanford']),
-                'srl': Predictor.from_path(MODEL2URL['srl'])}
+                'stanford': Predictor.from_path(
+                    configs['stanford_url'],
+                    cuda_device=next(cuda_devices)
+                ),
+                'srl': Predictor.from_path(
+                    configs['srl_url'],
+                    cuda_device=next(cuda_devices)
+                )
+            }
 
         if configs.overwrite_entries:
             logger.warning("`overwrite_entries` is set to True, this means "
@@ -99,13 +109,24 @@ class AllenNLPProcessor(PackProcessor):
             - allow_parallel_entries: whether to allow similar new entries when
                 they already exist, e.g. allowing new tokens with same spans,
                 used only when `overwrite_entries` is False.
+            - <model>_url: url of the corresponding model, default urls for
+                "stanford", "srl" and "universal" can be found in `MODEL2URL`.
+            - cuda_devices: a list of integers indicating the available
+                cuda/gpu devices that can be used by this processor. When
+                multiple models are loaded, cuda devices are assigned in a
+                round robin fashion. E.g. [0, -1] -> first model uses gpu 0
+                but second model uses cpu.
         """
         config = super().default_configs()
         config.update({
             'processors': "tokenize,pos,depparse",
             'tag_formalism': "stanford",
             'overwrite_entries': False,
-            'allow_parallel_entries': True
+            'allow_parallel_entries': True,
+            'stanford_url': MODEL2URL['stanford'],
+            'srl_url': MODEL2URL['srl'],
+            'universal_url': MODEL2URL['universal'],
+            'cuda_devices': [-1]
         })
         return config
 
@@ -143,7 +164,7 @@ class AllenNLPProcessor(PackProcessor):
             else:
                 # delete existing tokens and dependencies
                 for entry_type in (Token, Dependency):
-                    for entry in input_pack.get(entry_type):
+                    for entry in list(input_pack.get(entry_type)):
                         input_pack.delete_entry(entry)
 
     def _create_tokens(self, input_pack, sentence, result):
@@ -182,7 +203,6 @@ class AllenNLPProcessor(PackProcessor):
                                     tokens[pred_span.end].end)
             for arg_span, label in arguments:
                 arg = PredicateArgument(input_pack,
-                                        tokens[arg_span.begin].begin,
-                                        tokens[arg_span.end].end)
+                    tokens[arg_span.begin].begin, tokens[arg_span.end].end)
                 link = PredicateLink(input_pack, pred, arg)
                 link.arg_type = label

--- a/forte_wrapper/allennlp/allennlp_processors.py
+++ b/forte_wrapper/allennlp/allennlp_processors.py
@@ -203,6 +203,7 @@ class AllenNLPProcessor(PackProcessor):
                                     tokens[pred_span.end].end)
             for arg_span, label in arguments:
                 arg = PredicateArgument(input_pack,
-                    tokens[arg_span.begin].begin, tokens[arg_span.end].end)
+                                        tokens[arg_span.begin].begin,
+                                        tokens[arg_span.end].end)
                 link = PredicateLink(input_pack, pred, arg)
                 link.arg_type = label


### PR DESCRIPTION
### Description of changes
Adding two types for config options in AllenNLPProcessor
1. Model URL's.
2. Use gpu and basic control of gpu assignment (for each model)

### Possible influences of this PR.
N/A

### Test Conducted
Tested against a pipeline using AllenNLPProcessor.