### PR TITLE
add logic to control datapack content

### DIFF
--- a/forte_wrapper/elastic/elastic_search_processor.py
+++ b/forte_wrapper/elastic/elastic_search_processor.py
@@ -43,18 +43,19 @@ class ElasticSearchProcessor(MultiPackProcessor):
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:
-        r"""
+        """
         This defines a basic config structure for ElasticSearchProcessor.
         :return: A dictionary with the default config for this processor.
         Following are the keys for this dictionary:
             - query_pack_name: the query pack's name.
             - index_config: the ElasticSearchIndexer's config.
-            - field: Field name that will be used when creating new datapack
-            - response_pack_name_prefix: the pack name prefix to be used 
-            in response datapacks
-            - only_pass_content: boolean, defines if only the content field 
-            of the datapack should be passed to the multipack, default 
-            is True. If set False, the original datapack will be passed 
+            - field: Field name that will be used when creating the new
+            datapack.
+            - response_pack_name_prefix: the pack name prefix to be used
+            in response datapacks.
+            - only_pass_content: boolean, defines if only the content field
+            of the datapack should be passed to the multipack, default
+            is True. If set False, the original datapack will be passed
             to the multipack.
         """
         config = super().default_configs()

--- a/forte_wrapper/elastic/elastic_search_processor.py
+++ b/forte_wrapper/elastic/elastic_search_processor.py
@@ -43,6 +43,20 @@ class ElasticSearchProcessor(MultiPackProcessor):
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:
+        """
+        This defines a basic config structure for ElasticSearchProcessor.
+        :return: A dictionary with the default config for this processor.
+        Following are the keys for this dictionary:
+            - query_pack_name: the query pack's name.
+            - index_config: the ElasticSearchIndexer's config.
+            - field: Field name that will be used when creating new datapack
+            - response_pack_name_prefix: the pack name prefix to be used 
+            in response datapacks
+            - only_pass_content: boolean, defines if only the content field 
+            of the datapack should be passed to the multipack, default 
+            is True. If set False, the original datapack will be passed 
+            to the multipack.
+        """
         config = super().default_configs()
         config.update({
             "query_pack_name": "query",

--- a/forte_wrapper/elastic/elastic_search_processor.py
+++ b/forte_wrapper/elastic/elastic_search_processor.py
@@ -56,7 +56,7 @@ class ElasticSearchProcessor(MultiPackProcessor):
             - indexed_text_only: boolean, defines whether the returned
                 value from the field (as specified by the field
                 configuration) will be considered as plain text. If True,
-                a new data pack will be created and the value will be 
+                a new data pack will be created and the value will be
                 used as the text for the data pack. Otherwise, the returned
                 value will be considered as serialized data pack, and the
                 returned data pack will be created by deserialization.

--- a/forte_wrapper/elastic/elastic_search_processor.py
+++ b/forte_wrapper/elastic/elastic_search_processor.py
@@ -43,7 +43,7 @@ class ElasticSearchProcessor(MultiPackProcessor):
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:
-        """
+        r"""
         This defines a basic config structure for ElasticSearchProcessor.
         :return: A dictionary with the default config for this processor.
         Following are the keys for this dictionary:

--- a/forte_wrapper/elastic/elastic_search_processor.py
+++ b/forte_wrapper/elastic/elastic_search_processor.py
@@ -44,7 +44,6 @@ class ElasticSearchProcessor(MultiPackProcessor):
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:
         """This defines a basic config structure for ElasticSearchProcessor
-        
         Returns:
             A dictionary with the default config for this processor.
             query_pack_name (str): The query pack's name, default is "query".

--- a/forte_wrapper/elastic/elastic_search_processor.py
+++ b/forte_wrapper/elastic/elastic_search_processor.py
@@ -53,10 +53,13 @@ class ElasticSearchProcessor(MultiPackProcessor):
             datapack.
             - response_pack_name_prefix: the pack name prefix to be used
             in response datapacks.
-            - only_pass_content: boolean, defines if only the content field
-            of the datapack should be passed to the multipack, default
-            is True. If set False, the original datapack will be passed
-            to the multipack.
+            - indexed_text_only: boolean, defines whether the returned
+            value from the field (as specified by the field configuration)
+             will be considered as plain text. If True, a new data pack
+             will be created and the value will be used as the text for
+             the data pack. Otherwise, the returned value will be
+             considered as serialized data pack, and the returned data
+             pack will be created by deserialization. Default is True.
         """
         config = super().default_configs()
         config.update({
@@ -64,7 +67,7 @@ class ElasticSearchProcessor(MultiPackProcessor):
             "index_config": ElasticSearchIndexer.default_configs(),
             "field": "content",
             "response_pack_name_prefix": "passage",
-            "only_pass_content": True
+            "indexed_text_only": True
         })
         return config
 
@@ -96,7 +99,7 @@ class ElasticSearchProcessor(MultiPackProcessor):
             document = hit["_source"]
             first_query.add_result(document["doc_id"], hit["_score"])
 
-            if self.configs.only_pass_content:
+            if self.configs.indexed_text_only:
                 pack: DataPack = input_pack.add_pack(
                     f"{self.configs.response_pack_name_prefix}_{idx}"
                 )

--- a/forte_wrapper/elastic/elastic_search_processor.py
+++ b/forte_wrapper/elastic/elastic_search_processor.py
@@ -50,16 +50,17 @@ class ElasticSearchProcessor(MultiPackProcessor):
             - query_pack_name: the query pack's name.
             - index_config: the ElasticSearchIndexer's config.
             - field: Field name that will be used when creating the new
-            datapack.
+                datapack.
             - response_pack_name_prefix: the pack name prefix to be used
-            in response datapacks.
+                in response datapacks.
             - indexed_text_only: boolean, defines whether the returned
-            value from the field (as specified by the field configuration)
-             will be considered as plain text. If True, a new data pack
-             will be created and the value will be used as the text for
-             the data pack. Otherwise, the returned value will be
-             considered as serialized data pack, and the returned data
-             pack will be created by deserialization. Default is True.
+                value from the field (as specified by the field
+                configuration) will be considered as plain text. If True,
+                a new data pack will be created and the value will be 
+                used as the text for the data pack. Otherwise, the returned
+                value will be considered as serialized data pack, and the
+                returned data pack will be created by deserialization.
+                Default is True.
         """
         config = super().default_configs()
         config.update({

--- a/forte_wrapper/elastic/elastic_search_processor.py
+++ b/forte_wrapper/elastic/elastic_search_processor.py
@@ -43,17 +43,17 @@ class ElasticSearchProcessor(MultiPackProcessor):
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:
-        """
-        This defines a basic config structure for ElasticSearchProcessor.
-        :return: A dictionary with the default config for this processor.
-        Following are the keys for this dictionary:
-            - query_pack_name: the query pack's name.
-            - index_config: the ElasticSearchIndexer's config.
-            - field: Field name that will be used when creating the new
+        """This defines a basic config structure for ElasticSearchProcessor
+        
+        Returns:
+            A dictionary with the default config for this processor.
+            query_pack_name (str): The query pack's name, default is "query".
+            index_config (dict): The ElasticSearchIndexer's config.
+            field (str): Field name that will be used when creating the new
                 datapack.
-            - response_pack_name_prefix: the pack name prefix to be used
+            response_pack_name_prefix (str): the pack name prefix to be used
                 in response datapacks.
-            - indexed_text_only: boolean, defines whether the returned
+            indexed_text_only (bool): defines whether the returned
                 value from the field (as specified by the field
                 configuration) will be considered as plain text. If True,
                 a new data pack will be created and the value will be


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte-wrappers/issues/14. 

### Description of changes
add a param "only_pass_content" to control if only the content of datapack added to the multipack, or all info in original datapack.

Describe what are the changes, and how they solve the problem.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
