### PR TITLE
add record and expected types and attributes for nltk

### DIFF
--- a/forte_wrapper/allennlp/allennlp_processors.py
+++ b/forte_wrapper/allennlp/allennlp_processors.py
@@ -246,6 +246,8 @@ class AllenNLPProcessor(PackProcessor):
     def expected_types_and_attributes(cls) -> Dict[str, Set[str]]:
         r"""Method to add expected type for current processor input which
         would be checked before running the processor if
+        the pipeline is initialized with
+        `enforce_consistency=True` or
         :meth:`~forte.pipeline.Pipeline.enforce_consistency` was enabled for
         the pipeline.
         """

--- a/forte_wrapper/nltk/nltk_processors.py
+++ b/forte_wrapper/nltk/nltk_processors.py
@@ -48,7 +48,8 @@ class NLTKWordTokenizer(PackProcessor):
             Token(input_pack, begin, end)
 
     def record(self, record_meta: Dict[str, Set[str]]):
-        r"""Method to add output type record of current processor
+        r"""Method to add output type record of `NLTKWordTokenizer`, which is
+        `ft.onto.base_ontology.Token`,
         to :attr:`forte.data.data_pack.Meta.record`.
 
         Args:
@@ -79,19 +80,20 @@ class NLTKPOSTagger(PackProcessor):
             token.pos = tag[1]
 
     def record(self, record_meta: Dict[str, Set[str]]):
-        r"""Method to add output type record of current processor
+        r"""Method to add output type record of `NLTKPOSTagger`, which adds
+        attribute `pos` to `ft.onto.base_ontology.Token`
         to :attr:`forte.data.data_pack.Meta.record`.
 
         Args:
             record_meta: the field in the datapack for type record that need to
                 fill in for consistency checking.
         """
-        record_meta["ft.onto.base_ontology.Token"] = {"pos"}
+        record_meta["ft.onto.base_ontology.Token"].add("pos")
 
     @classmethod
     def expected_types_and_attributes(cls):
-        r"""Method to add expected type for current processor input which
-        would be checked before running the processor if
+        r"""Method to add expected type `ft.onto.base_ontology.Token` for input
+        which would be checked before running the processor if
         the pipeline is initialized with
         `enforce_consistency=True` or
         :meth:`~forte.pipeline.Pipeline.enforce_consistency` was enabled for
@@ -130,7 +132,8 @@ class NLTKLemmatizer(PackProcessor):
             token.lemma = lemma
 
     def record(self, record_meta: Dict[str, Set[str]]):
-        r"""Method to add output type record of current processor
+        r"""Method to add output type record of `NLTKLemmatizer` which adds
+        attribute `lemma` to `ft.onto.base_ontology.Token`
         to :attr:`forte.data.data_pack.Meta.record`.
 
         Args:
@@ -141,7 +144,8 @@ class NLTKLemmatizer(PackProcessor):
 
     @classmethod
     def expected_types_and_attributes(cls):
-        r"""Method to add expected type for current processor input which
+        r"""Method to add expected type `ft.onto.base_ontology.Token` with
+        attribute `pos` which
         would be checked before running the processor if
         the pipeline is initialized with
         `enforce_consistency=True` or
@@ -213,7 +217,8 @@ class NLTKChunker(PackProcessor):
                     index += 1
 
     def record(self, record_meta: Dict[str, Set[str]]):
-        r"""Method to add output type record of current processor
+        r"""Method to add output type record of `NLTKChunker` which adds
+        `ft.onto.base_ontology.Phrase` with attribute `phrase_type`
         to :attr:`forte.data.data_pack.Meta.record`.
 
         Args:
@@ -224,7 +229,8 @@ class NLTKChunker(PackProcessor):
 
     @classmethod
     def expected_types_and_attributes(cls):
-        r"""Method to add expected type for current processor input which
+        r"""Method to add expected type ft.onto.base_ontology.Token` with
+        attribute `pos` and `ft.onto.base_ontology.Sentence` which
         would be checked before running the processor if
         the pipeline is initialized with
         `enforce_consistency=True` or
@@ -252,7 +258,8 @@ class NLTKSentenceSegmenter(PackProcessor):
             Sentence(input_pack, begin, end)
 
     def record(self, record_meta: Dict[str, Set[str]]):
-        r"""Method to add output type record of current processor
+        r"""Method to add output type record of `NLTKSentenceSegmenter`, which
+        is `ft.onto.base_ontology.Sentence`
         to :attr:`forte.data.data_pack.Meta.record`.
 
         Args:
@@ -299,7 +306,8 @@ class NLTKNER(PackProcessor):
                     index += 1
 
     def record(self, record_meta: Dict[str, Set[str]]):
-        r"""Method to add output type record of current processor
+        r"""Method to add output type record of `NLTKNER` which is
+        `ft.onto.base_ontology.EntityMention` with attribute `phrase_type`
         to :attr:`forte.data.data_pack.Meta.record`.
 
         Args:
@@ -310,7 +318,8 @@ class NLTKNER(PackProcessor):
 
     @classmethod
     def expected_types_and_attributes(cls):
-        r"""Method to add expected type for current processor input which
+        r"""Method to add expected type ft.onto.base_ontology.Token` with
+        attribute `pos` and `ft.onto.base_ontology.Sentence` which
         would be checked before running the processor if
         the pipeline is initialized with
         `enforce_consistency=True` or

--- a/forte_wrapper/nltk/nltk_processors.py
+++ b/forte_wrapper/nltk/nltk_processors.py
@@ -148,7 +148,7 @@ class NLTKLemmatizer(PackProcessor):
         :meth:`~forte.pipeline.Pipeline.enforce_consistency` was enabled for
         the pipeline.
         """
-        return {"ft.onto.base_ontology.Token": "pos"}
+        return {"ft.onto.base_ontology.Token": {"pos"}}
 
 
 def penn2morphy(penntag: str) -> str:
@@ -318,4 +318,4 @@ class NLTKNER(PackProcessor):
         the pipeline.
         """
         return {"ft.onto.base_ontology.Sentence": set(),
-                "ft.onto.base_ontology.Token": "pos"}
+                "ft.onto.base_ontology.Token": {"pos"}}

--- a/forte_wrapper/nltk/nltk_processors.py
+++ b/forte_wrapper/nltk/nltk_processors.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
+from typing import List, Dict, Set
 
 import nltk
 from nltk import pos_tag, ne_chunk, PunktSentenceTokenizer
@@ -47,6 +47,16 @@ class NLTKWordTokenizer(PackProcessor):
         for begin, end in self.tokenizer.span_tokenize(input_pack.text):
             Token(input_pack, begin, end)
 
+    def record(self, record_meta: Dict[str, Set[str]]):
+        r"""Method to add output type record of current processor
+        to :attr:`forte.data.data_pack.Meta.record`.
+
+        Args:
+            record_meta: the field in the datapack for type record that need to
+                fill in for consistency checking.
+        """
+        record_meta["ft.onto.base_ontology.Token"] = set()
+
 
 class NLTKPOSTagger(PackProcessor):
     r"""A wrapper of NLTK pos tagger.
@@ -67,6 +77,27 @@ class NLTKPOSTagger(PackProcessor):
         taggings = pos_tag(token_texts)
         for token, tag in zip(token_entries, taggings):
             token.pos = tag[1]
+
+    def record(self, record_meta: Dict[str, Set[str]]):
+        r"""Method to add output type record of current processor
+        to :attr:`forte.data.data_pack.Meta.record`.
+
+        Args:
+            record_meta: the field in the datapack for type record that need to
+                fill in for consistency checking.
+        """
+        record_meta["ft.onto.base_ontology.Token"] = {"pos"}
+
+    @classmethod
+    def expected_types_and_attributes(cls):
+        r"""Method to add expected type for current processor input which
+        would be checked before running the processor if
+        the pipeline is initialized with
+        `enforce_consistency=True` or
+        :meth:`~forte.pipeline.Pipeline.enforce_consistency` was enabled for
+        the pipeline.
+        """
+        return {"ft.onto.base_ontology.Token": set()}
 
 
 class NLTKLemmatizer(PackProcessor):
@@ -97,6 +128,27 @@ class NLTKLemmatizer(PackProcessor):
                   for i in range(len(token_texts))]
         for token, lemma in zip(token_entries, lemmas):
             token.lemma = lemma
+
+    def record(self, record_meta: Dict[str, Set[str]]):
+        r"""Method to add output type record of current processor
+        to :attr:`forte.data.data_pack.Meta.record`.
+
+        Args:
+            record_meta: the field in the datapack for type record that need to
+                fill in for consistency checking.
+        """
+        record_meta["ft.onto.base_ontology.Token"].add("lemma")
+
+    @classmethod
+    def expected_types_and_attributes(cls):
+        r"""Method to add expected type for current processor input which
+        would be checked before running the processor if
+        the pipeline is initialized with
+        `enforce_consistency=True` or
+        :meth:`~forte.pipeline.Pipeline.enforce_consistency` was enabled for
+        the pipeline.
+        """
+        return {"ft.onto.base_ontology.Token": "pos"}
 
 
 def penn2morphy(penntag: str) -> str:
@@ -160,6 +212,28 @@ class NLTKChunker(PackProcessor):
                     # chunk: ('is', 'VBZ')
                     index += 1
 
+    def record(self, record_meta: Dict[str, Set[str]]):
+        r"""Method to add output type record of current processor
+        to :attr:`forte.data.data_pack.Meta.record`.
+
+        Args:
+            record_meta: the field in the datapack for type record that need to
+                fill in for consistency checking.
+        """
+        record_meta["ft.onto.base_ontology.Phrase"] = {"phrase_type"}
+
+    @classmethod
+    def expected_types_and_attributes(cls):
+        r"""Method to add expected type for current processor input which
+        would be checked before running the processor if
+        the pipeline is initialized with
+        `enforce_consistency=True` or
+        :meth:`~forte.pipeline.Pipeline.enforce_consistency` was enabled for
+        the pipeline.
+        """
+        return {"ft.onto.base_ontology.Sentence": set(),
+                "ft.onto.base_ontology.Token": {"pos"}}
+
 
 class NLTKSentenceSegmenter(PackProcessor):
     r"""A wrapper of NLTK sentence tokenizer.
@@ -176,6 +250,16 @@ class NLTKSentenceSegmenter(PackProcessor):
     def _process(self, input_pack: DataPack):
         for begin, end in self.sent_splitter.span_tokenize(input_pack.text):
             Sentence(input_pack, begin, end)
+
+    def record(self, record_meta: Dict[str, Set[str]]):
+        r"""Method to add output type record of current processor
+        to :attr:`forte.data.data_pack.Meta.record`.
+
+        Args:
+            record_meta: the field in the datapack for type record that need to
+                fill in for consistency checking.
+        """
+        record_meta["ft.onto.base_ontology.Sentence"] = set()
 
 
 class NLTKNER(PackProcessor):
@@ -213,3 +297,25 @@ class NLTKNER(PackProcessor):
                     # For example:
                     # chunk: ('This', 'DT')
                     index += 1
+
+    def record(self, record_meta: Dict[str, Set[str]]):
+        r"""Method to add output type record of current processor
+        to :attr:`forte.data.data_pack.Meta.record`.
+
+        Args:
+            record_meta: the field in the datapack for type record that need to
+                fill in for consistency checking.
+        """
+        record_meta["ft.onto.base_ontology.EntityMention"] = {"ner_type"}
+
+    @classmethod
+    def expected_types_and_attributes(cls):
+        r"""Method to add expected type for current processor input which
+        would be checked before running the processor if
+        the pipeline is initialized with
+        `enforce_consistency=True` or
+        :meth:`~forte.pipeline.Pipeline.enforce_consistency` was enabled for
+        the pipeline.
+        """
+        return {"ft.onto.base_ontology.Sentence": set(),
+                "ft.onto.base_ontology.Token": "pos"}

--- a/forte_wrapper/spacy/spacy_processors.py
+++ b/forte_wrapper/spacy/spacy_processors.py
@@ -142,7 +142,7 @@ class SpacyProcessor(PackProcessor):
         """
         record_meta["ft.onto.base_ontology.Sentence"] = set()
         if "ner" in self.processors:
-            record_meta["ft.onto.base_ontology.EntityMention"] = set()
+            record_meta["ft.onto.base_ontology.EntityMention"] = {"ner_type"}
         if "tokenize" in self.processors:
             record_meta["ft.onto.base_ontology.Token"] = set()
             if "pos" in self.processors:

--- a/tests/nltk_processors_test.py
+++ b/tests/nltk_processors_test.py
@@ -28,7 +28,7 @@ from ft.onto.base_ontology import Token, Sentence, Phrase, EntityMention
 class TestNLTKSentenceSegmenter(unittest.TestCase):
 
     def setUp(self):
-        self.nltk = Pipeline[DataPack]()
+        self.nltk = Pipeline[DataPack](enforce_consistency=True)
         self.nltk.set_reader(StringReader())
         self.nltk.add(NLTKSentenceSegmenter())
         self.nltk.initialize()
@@ -47,7 +47,7 @@ class TestNLTKSentenceSegmenter(unittest.TestCase):
 class TestNLTKWordTokenizer(unittest.TestCase):
 
     def setUp(self):
-        self.nltk = Pipeline[DataPack]()
+        self.nltk = Pipeline[DataPack](enforce_consistency=True)
         self.nltk.set_reader(StringReader())
         self.nltk.add(NLTKSentenceSegmenter())
         self.nltk.add(NLTKWordTokenizer())
@@ -74,7 +74,7 @@ class TestNLTKWordTokenizer(unittest.TestCase):
 class TestNLTKPOSTagger(unittest.TestCase):
 
     def setUp(self):
-        self.nltk = Pipeline[DataPack]()
+        self.nltk = Pipeline[DataPack](enforce_consistency=True)
         self.nltk.set_reader(StringReader())
         self.nltk.add(NLTKSentenceSegmenter())
         self.nltk.add(NLTKWordTokenizer())
@@ -101,7 +101,7 @@ class TestNLTKPOSTagger(unittest.TestCase):
 class TestNLTKLemmatizer(unittest.TestCase):
 
     def setUp(self):
-        self.nltk = Pipeline[DataPack]()
+        self.nltk = Pipeline[DataPack](enforce_consistency=True)
         self.nltk.set_reader(StringReader())
         self.nltk.add(NLTKSentenceSegmenter())
         self.nltk.add(NLTKWordTokenizer())
@@ -130,7 +130,7 @@ class TestNLTKLemmatizer(unittest.TestCase):
 class TestNLTKChunker(unittest.TestCase):
 
     def setUp(self):
-        self.nltk = Pipeline[DataPack]()
+        self.nltk = Pipeline[DataPack](enforce_consistency=True)
         self.nltk.set_reader(StringReader())
         self.nltk.add(NLTKSentenceSegmenter())
         self.nltk.add(NLTKWordTokenizer())
@@ -160,7 +160,7 @@ class TestNLTKChunker(unittest.TestCase):
 class TestNLTKNER(unittest.TestCase):
 
     def setUp(self):
-        self.nltk = Pipeline[DataPack]()
+        self.nltk = Pipeline[DataPack](enforce_consistency=True)
         self.nltk.set_reader(StringReader())
         self.nltk.add(NLTKSentenceSegmenter())
         self.nltk.add(NLTKWordTokenizer())


### PR DESCRIPTION
This PR fixes #23. 

In tests for nltk, enabled enforce_consistency=True for all the pipelines and passed the checking for all the current pipelines.
