### PR TITLE
Fix update_all_version.sh for Linux

### DIFF
--- a/scripts/update_all_version.sh
+++ b/scripts/update_all_version.sh
@@ -1,4 +1,8 @@
 for f in src/*/setup.py; do
     echo "Processing $f"
-    sed -r -i "" "s/version=\"[0-9A-Za-z\.]+\",/version=\"$1\",/1" $f
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -r -i "" "s/version=\"[0-9A-Za-z\.]+\",/version=\"$1\",/1" $f
+    else
+        sed -r -i "s/version=\"[0-9A-Za-z\.]+\",/version=\"$1\",/1" $f
+    fi
 done


### PR DESCRIPTION
This PR fixes a bug in `update_all_version.sh` for Linux. 

### Description of changes
`sed` has different usage in Linux and OSX. This PR update `update_all_version.sh` to address the platform dependency issue.

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Run:
```bash
. ./scripts/update_all_version.sh <new version>
```
in both macOS and Linux environment.
