### PR TITLE
Update DataPack (de)serialize to from_string/to_string in forte.elastic

### DIFF
--- a/src/elastic/fortex/elastic/elastic_search_index_processor.py
+++ b/src/elastic/fortex/elastic/elastic_search_index_processor.py
@@ -131,7 +131,7 @@ class ElasticSearchPackIndexProcessor(ElasticSearchIndexerBase):
         return [
             str(input_pack.pack_id),
             input_pack.text,
-            input_pack.serialize(True),
+            input_pack.to_string(True),
         ]
 
     def _field_names(self) -> List[str]:

--- a/src/elastic/fortex/elastic/elastic_search_processor.py
+++ b/src/elastic/fortex/elastic/elastic_search_processor.py
@@ -109,7 +109,7 @@ class ElasticSearchProcessor(MultiPackProcessor):
                 Document(pack=pack, begin=0, end=len(content))
 
             else:
-                pack = DataPack.deserialize(document["pack_info"])
+                pack = DataPack.from_string(document["pack_info"])
                 input_pack.add_pack_(
                     pack, f"{self.configs.response_pack_name_prefix}_{idx}"
                 )


### PR DESCRIPTION
### Description of changes
Forte has updated its (de)serialize interface for `BasePack` (https://github.com/asyml/forte/commit/8ee2c6ce26522b7210ba29dd29cd21b0b15c0812#diff-08f2c9d027629fa160cbf4bbd3d8df70b58889cdd88632b3e369126c1c84d447), so we need to update forte.elastic to make it compatible with the latest version of forte.
