### PR TITLE
Update tensorflow version requirement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
           - { dep: "nltk gpt2", extra: "termcolor>=1.1.0", testfile: examples/gpt2_test.py }
           - { dep: elastic, testfile: tests/wrappers/elastic_indexers_test.py }
           - { dep: faiss, testfile: tests/wrappers/faiss_indexers_test.py }
-          - { dep: "huggingface nltk", extra: "tensorflow>=2.5.0", testfile: tests/wrappers/huggingface }
+          - { dep: "huggingface nltk", extra: "tensorflow>=2.5.0,<2.8.0", testfile: tests/wrappers/huggingface }
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
           - { dep: "nltk gpt2", extra: "termcolor>=1.1.0", testfile: examples/gpt2_test.py }
           - { dep: elastic, testfile: tests/wrappers/elastic_indexers_test.py }
           - { dep: faiss, testfile: tests/wrappers/faiss_indexers_test.py }
-          - { dep: "huggingface nltk", extra: "tensorflow>=2.5.0,<2.8.0", testfile: tests/wrappers/huggingface }
+          - { dep: "huggingface nltk", extra: "'tensorflow>=2.5.0,<2.8.0'", testfile: tests/wrappers/huggingface }
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
The current GitHub workflow is broken in pytest of `huggingface nltk`. This PR adds a version limit of `<2.8.0` to `tensorflow` in order to solve the issue.
