### PR TITLE
Elasticsearch requirement based on python ver in forte.elastic

### DIFF
--- a/src/elastic/setup.py
+++ b/src/elastic/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     install_requires=[
         "forte==0.1.2",
         "elasticsearch>=7.5.1; python_version<'3.9.0'",
-	"elasticsearch>=7.14.0; python_version>='3.9.0'"
+        "elasticsearch>=7.14.0; python_version>='3.9.0'",
     ],
     classifiers=[
         "Intended Audience :: Developers",

--- a/src/elastic/setup.py
+++ b/src/elastic/setup.py
@@ -29,7 +29,8 @@ setuptools.setup(
     platforms="any",
     install_requires=[
         "forte==0.1.2",
-        "elasticsearch==7.5.1",
+        "elasticsearch>=7.5.1; python_version<'3.9.0'",
+	"elasticsearch>=7.14.0; python_version>='3.9.0'"
     ],
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR fixes [forte-wrappers/issues/84](https://github.com/asyml/forte-wrappers/issues/84) and [forte/issues/627](https://github.com/asyml/forte/issues/627)

### Description of changes
Setup file has been updated to look for >7.14.0 versions for elastic search in `forte.elastic` for python version >= 3.9.0, since elasticsearch 7.5.1 uses code removed from python 3.9.0 onwards.

### Possible influences of this PR.
Should be able to install `forte.elastic` on any python version >3.6 (forte requirement) without the `ImportError`
