### PR TITLE
Import statements fixed in example

### DIFF
--- a/src/huggingface/fortex/huggingface/biobert_ner/ner_predict_example.py
+++ b/src/huggingface/fortex/huggingface/biobert_ner/ner_predict_example.py
@@ -21,9 +21,9 @@ from forte.common.configuration import Config
 from forte.data.data_pack import DataPack
 from forte.data.readers import StringReader
 from forte.pipeline import Pipeline
-from forte.hugginface.transformers_processor import BERTTokenizer
-from forte.hugginface.bio_ner_predictor import BioBERTNERPredictor
-from forte.nltk.nltk_processors import NLTKSentenceSegmenter
+from fortex.huggingface.transformers_processor import BERTTokenizer
+from fortex.huggingface.bio_ner_predictor import BioBERTNERPredictor
+from fortex.nltk.nltk_processors import NLTKSentenceSegmenter
 
 
 def main(config: Config):


### PR DESCRIPTION
This tiny PR fixes [#82](https://github.com/asyml/forte-wrappers/issues/82) 

### Description of changes
import statements fixed

### Possible influences of this PR.
The example shouldn't throw `ModuleNotFound` exception anymore.

