### PR TITLE
Ftx namespace changes to processors

### DIFF
--- a/src/spacy/fortex/spacy/spacy_processors.py
+++ b/src/spacy/fortex/spacy/spacy_processors.py
@@ -28,7 +28,7 @@ from forte.data.data_pack import DataPack
 from forte.data.ontology import Annotation
 from forte.processors.base import PackProcessor, FixedSizeBatchProcessor
 from ft.onto.base_ontology import EntityMention, Sentence, Token, Dependency
-from ftx.medical.clinical import MedicalEntityMention, UMLSConceptLink
+from ftx.onto.clinical import MedicalEntityMention, UMLSConceptLink
 
 __all__ = [
     "SpacyProcessor",

--- a/src/spacy/fortex/spacy/spacy_processors.py
+++ b/src/spacy/fortex/spacy/spacy_processors.py
@@ -28,7 +28,7 @@ from forte.data.data_pack import DataPack
 from forte.data.ontology import Annotation
 from forte.processors.base import PackProcessor, FixedSizeBatchProcessor
 from ft.onto.base_ontology import EntityMention, Sentence, Token, Dependency
-from ftx.medical import MedicalEntityMention, UMLSConceptLink
+from ftx.medical.clinical import MedicalEntityMention, UMLSConceptLink
 
 __all__ = [
     "SpacyProcessor",


### PR DESCRIPTION
This PR fixes #87 

### Description of changes
With reference to changes merged through Forte in [PR](https://github.com/asyml/forte/pull/648), we updated the ontology namespace structure. The processors in Forte-wrapper needed to incorporate those updated namespaces. Only `SpacyProcessor` works with the `ftx` folder, hence that's the only file that has been updated.

### Possible influences of this PR.
Code shouldn't throw Import errors now.
