### PR TITLE
Numpy typing fix

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,7 +9,7 @@ follow_imports = silent
 ignore_missing_imports = True
 mypy_path = ./
 allow_redefinition = True
-plugins = numpy.typing.mypy_plugin
+
 
 [mypy-torch]
 follow_imports = skip

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,9 +9,11 @@ follow_imports = silent
 ignore_missing_imports = True
 mypy_path = ./
 allow_redefinition = True
+plugins = numpy.typing.mypy_plugin
 
 [mypy-torch]
 follow_imports = skip
 
 [mypy-numpy]
 follow_imports = skip
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,7 +10,6 @@ ignore_missing_imports = True
 mypy_path = ./
 allow_redefinition = True
 
-
 [mypy-torch]
 follow_imports = skip
 

--- a/src/huggingface/fortex/huggingface/bio_ner_predictor.py
+++ b/src/huggingface/fortex/huggingface/bio_ner_predictor.py
@@ -68,7 +68,7 @@ class BioBERTNERPredictor(RequestPackingProcessor):
     @torch.no_grad()
     def predict(
         self, data_batch: Dict[str, Dict[str, List[str]]]
-    ) -> Dict[str, Dict[str, List]]: # numpy typing is removed due to
+    ) -> Dict[str, Dict[str, List]]:  # numpy typing is removed due to
         # incompatibility issues due to upgrading from numpy verions 1.19 to
         # 1.21
         sentences = data_batch["context"]

--- a/src/huggingface/fortex/huggingface/bio_ner_predictor.py
+++ b/src/huggingface/fortex/huggingface/bio_ner_predictor.py
@@ -68,7 +68,7 @@ class BioBERTNERPredictor(RequestPackingProcessor):
     @torch.no_grad()
     def predict(
         self, data_batch: Dict[str, Dict[str, List[str]]]
-    ) -> Dict[str, Dict[str, List[np.array]]]: # type: ignore
+    ) -> Dict[str, Dict[str, List[np.array]]]:  # type: ignore
         sentences = data_batch["context"]
         subwords = data_batch["Subword"]
 

--- a/src/huggingface/fortex/huggingface/bio_ner_predictor.py
+++ b/src/huggingface/fortex/huggingface/bio_ner_predictor.py
@@ -68,7 +68,7 @@ class BioBERTNERPredictor(RequestPackingProcessor):
     @torch.no_grad()
     def predict(
         self, data_batch: Dict[str, Dict[str, List[str]]]
-    ) -> Dict[str, Dict[str, List[np.typing.NDArray[np.int_]]]]:
+    ) -> Dict[str, Dict[str, List[np.array]]]:
         sentences = data_batch["context"]
         subwords = data_batch["Subword"]
 

--- a/src/huggingface/fortex/huggingface/bio_ner_predictor.py
+++ b/src/huggingface/fortex/huggingface/bio_ner_predictor.py
@@ -68,7 +68,7 @@ class BioBERTNERPredictor(RequestPackingProcessor):
     @torch.no_grad()
     def predict(
         self, data_batch: Dict[str, Dict[str, List[str]]]
-    ) -> Dict[str, Dict[str, List[np.array]]]:
+    ) -> Dict[str, Dict[str, List[np.darray]]]:
         sentences = data_batch["context"]
         subwords = data_batch["Subword"]
 

--- a/src/huggingface/fortex/huggingface/bio_ner_predictor.py
+++ b/src/huggingface/fortex/huggingface/bio_ner_predictor.py
@@ -68,7 +68,7 @@ class BioBERTNERPredictor(RequestPackingProcessor):
     @torch.no_grad()
     def predict(
         self, data_batch: Dict[str, Dict[str, List[str]]]
-    ) -> Dict[str, Dict[str, List[np.array]]]:
+    ) -> Dict[str, Dict[str, List[np.array]]]: # type: ignore
         sentences = data_batch["context"]
         subwords = data_batch["Subword"]
 

--- a/src/huggingface/fortex/huggingface/bio_ner_predictor.py
+++ b/src/huggingface/fortex/huggingface/bio_ner_predictor.py
@@ -68,7 +68,9 @@ class BioBERTNERPredictor(RequestPackingProcessor):
     @torch.no_grad()
     def predict(
         self, data_batch: Dict[str, Dict[str, List[str]]]
-    ) -> Dict[str, Dict[str, List[np.array]]]:  # type: ignore
+    ) -> Dict[str, Dict[str, List]]: # numpy typing is removed due to
+        # incompatibility issues due to upgrading from numpy verions 1.19 to
+        # 1.21
         sentences = data_batch["context"]
         subwords = data_batch["Subword"]
 

--- a/src/huggingface/fortex/huggingface/bio_ner_predictor.py
+++ b/src/huggingface/fortex/huggingface/bio_ner_predictor.py
@@ -68,7 +68,7 @@ class BioBERTNERPredictor(RequestPackingProcessor):
     @torch.no_grad()
     def predict(
         self, data_batch: Dict[str, Dict[str, List[str]]]
-    ) -> Dict[str, Dict[str, List[np.darray]]]:
+    ) -> Dict[str, Dict[str, List[np.typing.NDArray[np.int_]]]]:
         sentences = data_batch["context"]
         subwords = data_batch["Subword"]
 

--- a/src/huggingface/setup.py
+++ b/src/huggingface/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "forte==0.1.2",
         "more-itertools>=8.0.0",
         "transformers == 4.2.2",
-        "numpy == 1.19.5",
+        "numpy >= 1.21",
     ],
     classifiers=[
         "Intended Audience :: Developers",

--- a/src/huggingface/setup.py
+++ b/src/huggingface/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "forte==0.1.2",
         "more-itertools>=8.0.0",
         "transformers == 4.2.2",
-        "numpy >= 1.21",
+        "numpy == 1.19.5",
     ],
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR fixes https://github.com/asyml/forte-wrappers/issues/91. 

### Description of changes
Make sure numpy typing is compatible with numpy==1.21

### Possible influences of this PR.
Typing names are no longer compatible with numpy==1.19 but linting with mypy in CI test only checks typing under numpy==1.21.

### Test Conducted
Describe what test cases are included for the PR.
