### PR TITLE
Support NER and Bio NER using stanza processor.

### DIFF
--- a/tests/wrappers/stanfordnlp_processor_test.py
+++ b/tests/wrappers/stanfordnlp_processor_test.py
@@ -94,14 +94,14 @@ class TestStanfordNLPProcessor(unittest.TestCase):
 
         entities_entries = list(pack.get(entry_type=EntityMention))
 
-        texts = ['Forte', 'NLP']
-        types = ['ORG','ORG']
+        target_texts = ['Forte', 'NLP']
+        target_types = ['ORG','ORG']
         entities_text = [x.text for x in entities_entries]
         entities_type = [x.ner_type for x in entities_entries]
 
         # ner assertation
-        self.assertEqual(entities_text, texts)
-        self.assertEqual(entities_type, types)
+        self.assertEqual(entities_text, target_texts)
+        self.assertEqual(entities_type, target_types)
 
         
 class TestStanfordBioNERProcessor(unittest.TestCase):

--- a/tests/wrappers/stanfordnlp_processor_test.py
+++ b/tests/wrappers/stanfordnlp_processor_test.py
@@ -96,6 +96,7 @@ class TestStanfordNLPProcessor(unittest.TestCase):
 
         target_texts = ['Forte', 'NLP']
         target_types = ['ORG','ORG']
+
         entities_text = [x.text for x in entities_entries]
         entities_type = [x.ner_type for x in entities_entries]
 
@@ -121,7 +122,6 @@ class TestStanfordBioNERProcessor(unittest.TestCase):
         ]
         document = " ".join(sentences)
 
-        print(document)
         pack = self.stanford_nlp.process(document)
 
         for idx, sentence in enumerate(pack.get(Sentence)):
@@ -132,9 +132,11 @@ class TestStanfordBioNERProcessor(unittest.TestCase):
 
         target_texts = ['appendicitis', 'gastroenteritis', 'the acute pancreatitis']
         target_types = ['PROBLEM', 'PROBLEM', 'PROBLEM']
+
         entities_text = [x.text for x in entities_entries]
         entities_type = [x.ner_type for x in entities_entries]
 
+        # bio ner assertation
         self.assertEqual(entities_text, target_texts)
         self.assertEqual(entities_type, target_types)
 

--- a/tests/wrappers/stanfordnlp_processor_test.py
+++ b/tests/wrappers/stanfordnlp_processor_test.py
@@ -14,13 +14,14 @@
 """
 Unit tests for Stanford NLP processors.
 """
+import imp
 import os
 import unittest
 
 from forte.data.data_pack import DataPack
 from forte.pipeline import Pipeline
 from forte.data.readers import StringReader
-from fortex.stanza import StandfordNLPProcessor, StanfordNLPBioNERProcessor
+from fortex.stanza import StandfordNLPProcessor
 from ft.onto.base_ontology import Token, Sentence, EntityMention
 
 
@@ -29,7 +30,13 @@ class TestStanfordNLPProcessor(unittest.TestCase):
         self.stanford_nlp = Pipeline[DataPack]()
         self.stanford_nlp.set_reader(StringReader())
         config = {
-            "processors": "tokenize,pos,lemma,depparse,ner",
+            "processors":{
+               "tokenize":"default",
+               "pos":"defualt",
+               "lemma":"default",
+               "depparse":"default",
+               "ner":"i2b2"
+            },
             "lang": "en",
             # Language code for the language to build the Pipeline
             "use_gpu": False,
@@ -42,7 +49,6 @@ class TestStanfordNLPProcessor(unittest.TestCase):
             "This tool is called Forte.",
             "The goal of this project to help you build NLP " "pipelines.",
             "NLP has never been made this easy before."
-            # "I have to say I am suffering headache and acutebronchitis."
         ]
         document = " ".join(sentences)
         pack = self.stanford_nlp.process(document)
@@ -92,27 +98,6 @@ class TestStanfordNLPProcessor(unittest.TestCase):
                 self.assertEqual(token.text, tokens[i][j])
                 self.assertEqual(token.pos, pos[i][j])
 
-        entities_entries = list(pack.get(entry_type=EntityMention))
-
-        target_texts = ['Forte', 'NLP']
-        target_types = ['ORG','ORG']
-
-        entities_text = [x.text for x in entities_entries]
-        entities_type = [x.ner_type for x in entities_entries]
-
-        # ner assertation
-        self.assertEqual(entities_text, target_texts)
-        self.assertEqual(entities_type, target_types)
-
-        
-class TestStanfordBioNERProcessor(unittest.TestCase):
-    def setUp(self):
-        self.stanford_nlp = Pipeline[DataPack]()
-        self.stanford_nlp.set_reader(StringReader())
-        self.stanford_nlp.add(StanfordNLPBioNERProcessor())
-        self.stanford_nlp.initialize()
-
-    def test_stanford_processing(self):
         sentences = [
             "I lived in New York.",
             "Yesterday my stomach ached violently.",
@@ -124,10 +109,6 @@ class TestStanfordBioNERProcessor(unittest.TestCase):
 
         pack = self.stanford_nlp.process(document)
 
-        for idx, sentence in enumerate(pack.get(Sentence)):
-            # sentence assertation
-            self.assertEqual(sentence.text, sentences[idx])
-        
         entities_entries = list(pack.get(entry_type=EntityMention))
 
         target_texts = ['appendicitis', 'gastroenteritis', 'the acute pancreatitis']

--- a/tests/wrappers/stanfordnlp_processor_test.py
+++ b/tests/wrappers/stanfordnlp_processor_test.py
@@ -20,7 +20,8 @@ import unittest
 from forte.data.data_pack import DataPack
 from forte.pipeline import Pipeline
 from forte.data.readers import StringReader
-from fortex.stanza import StandfordNLPProcessor
+from fortex.stanza import StandfordNLPProcessor, StanfordNLPBioNERProcessor
+from ft.onto.base_ontology import Token, Sentence, EntityMention
 
 
 class TestStanfordNLPProcessor(unittest.TestCase):
@@ -28,7 +29,7 @@ class TestStanfordNLPProcessor(unittest.TestCase):
         self.stanford_nlp = Pipeline[DataPack]()
         self.stanford_nlp.set_reader(StringReader())
         config = {
-            "processors": "tokenize",
+            "processors": "tokenize,pos,lemma,depparse,ner",
             "lang": "en",
             # Language code for the language to build the Pipeline
             "use_gpu": False,
@@ -36,14 +37,106 @@ class TestStanfordNLPProcessor(unittest.TestCase):
         self.stanford_nlp.add(StandfordNLPProcessor(), config=config)
         self.stanford_nlp.initialize()
 
-    def test_stanford_processor(self):
+    def test_stanford_processing(self):
         sentences = [
             "This tool is called Forte.",
             "The goal of this project to help you build NLP " "pipelines.",
-            "NLP has never been made this easy before.",
+            "NLP has never been made this easy before."
+            # "I have to say I am suffering headache and acutebronchitis."
         ]
         document = " ".join(sentences)
-        self.stanford_nlp.process(document)
+        pack = self.stanford_nlp.process(document)
+
+        for idx, sentence in enumerate(pack.get(Sentence)):
+            # sentence assertation
+            self.assertEqual(sentence.text, sentences[idx])
+        
+        tokens = [
+            ["This", "tool", "is", "called", "Forte", "."],
+            [
+                "The",
+                "goal",
+                "of",
+                "this",
+                "project",
+                "to",
+                "help",
+                "you",
+                "build",
+                "NLP",
+                "pipelines",
+                "."
+            ],
+            [
+                "NLP",
+                "has",
+                "never",
+                "been",
+                "made",
+                "this",
+                "easy",
+                "before",
+                "."
+            ],
+        ]
+
+        pos = [['DET', 'NOUN', 'AUX', 'VERB', 'PROPN', 'PUNCT'], 
+        ['DET', 'NOUN', 'ADP', 'DET', 'NOUN', 'PART', 'VERB', 'PRON', 'VERB', 'NOUN', 'NOUN', 'PUNCT'], 
+        ['NOUN', 'AUX', 'ADV', 'AUX', 'VERB', 'PRON', 'ADJ', 'ADV', 'PUNCT']]
+
+        for i, sentence in enumerate(pack.get(Sentence)):
+            for j, token in enumerate(
+                pack.get(entry_type=Token, range_annotation=sentence)
+            ):
+                # token/pos assertation
+                self.assertEqual(token.text, tokens[i][j])
+                self.assertEqual(token.pos, pos[i][j])
+
+        entities_entries = list(pack.get(entry_type=EntityMention))
+
+        texts = ['Forte', 'NLP']
+        types = ['ORG','ORG']
+        entities_text = [x.text for x in entities_entries]
+        entities_type = [x.ner_type for x in entities_entries]
+
+        # ner assertation
+        self.assertEqual(entities_text, texts)
+        self.assertEqual(entities_type, types)
+
+        
+class TestStanfordBioNERProcessor(unittest.TestCase):
+    def setUp(self):
+        self.stanford_nlp = Pipeline[DataPack]()
+        self.stanford_nlp.set_reader(StringReader())
+        self.stanford_nlp.add(StanfordNLPBioNERProcessor())
+        self.stanford_nlp.initialize()
+
+    def test_stanford_processing(self):
+        sentences = [
+            "I lived in New York.",
+            "Yesterday my stomach ached violently.",
+            "I think it may be appendicitis or gastroenteritis.",
+            "Also it may be the acute pancreatitis.",
+            "Is this Forte?"
+        ]
+        document = " ".join(sentences)
+
+        print(document)
+        pack = self.stanford_nlp.process(document)
+
+        for idx, sentence in enumerate(pack.get(Sentence)):
+            # sentence assertation
+            self.assertEqual(sentence.text, sentences[idx])
+        
+        entities_entries = list(pack.get(entry_type=EntityMention))
+
+        target_texts = ['appendicitis', 'gastroenteritis', 'the acute pancreatitis']
+        target_types = ['PROBLEM', 'PROBLEM', 'PROBLEM']
+        entities_text = [x.text for x in entities_entries]
+        entities_type = [x.ner_type for x in entities_entries]
+
+        self.assertEqual(entities_text, target_texts)
+        self.assertEqual(entities_type, target_types)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes  asyml/ForteHealth#19. 

### Description of changes
I made the following two main changes in this PR:
1. Support NER in the class `StanfordNLPProcessor` in stanza_processor.py 
- You can add ner in the configuration of `StandfordNLPProcessor` to to get the EntityMention of your input data
2. Add a new processor `StanfordNLPBioNERProcessor` in stanza_processor.py to support Bio NER.
- You can add the processor in your pipeline to get the medical/ clinical/ biological EntityMention of the input data

Also, I made lots of changes in stanfordnlp_processor_test.py to test the effectiveness of my changes.

### Possible influences of this PR.
- Support basic NER and Bio NER using stanza processor.
- However, this may arise another issue, which I will give in ForteHeath: to support bio NER, I create another processor, because to get Bio NER, we should process our data based on the package mimic and i2b2. Maybe we should try to combine these two processor in one with different design of configurations.

### Test Conducted
All the test data are explicitly described in stanfordnlp_processor_test.py, and the tests of basic ner and bio ner are both successful. 

