### PR TITLE
Support Bio NER using stanza processor

### DIFF
--- a/src/stanza/fortex/stanza/stanza_processor.py
+++ b/src/stanza/fortex/stanza/stanza_processor.py
@@ -36,8 +36,9 @@ class StandfordNLPProcessor(PackProcessor):
         self.processors = dict()
 
     def set_up(self):
-        stanza.download(self.configs.lang, self.configs.dir, processors = self.configs.processors.todict())
         self.processors = dict(self.configs.processors)
+        stanza.download(self.configs.lang, self.configs.dir, processors = self.processors)
+        
 
     # pylint: disable=unused-argument
     def initialize(self, resources: Resources, configs: Config):
@@ -46,8 +47,6 @@ class StandfordNLPProcessor(PackProcessor):
             "pos" in configs.processors
             or "lemma" in configs.processors
             or "depparse" in configs.processors
-            # or "ner" in configs.processors
-            or "ner" in configs.processors
         ):
             if "tokenize" not in configs.processors:
                 raise ProcessorConfigError(
@@ -60,8 +59,9 @@ class StandfordNLPProcessor(PackProcessor):
             lang=self.configs.lang,
             dir=self.configs.dir,
             use_gpu=self.configs.use_gpu,
-            processors=self.configs.processors.todict(),
+            processors=self.processors,
         )
+        
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:

--- a/src/stanza/fortex/stanza/stanza_processor.py
+++ b/src/stanza/fortex/stanza/stanza_processor.py
@@ -24,9 +24,7 @@ from forte.common.resources import Resources
 from forte.data.data_pack import DataPack
 from forte.processors.base import PackProcessor
 
-__all__ = [
-    "StandfordNLPProcessor"
-]
+__all__ = ["StandfordNLPProcessor"]
 
 
 class StandfordNLPProcessor(PackProcessor):
@@ -38,10 +36,8 @@ class StandfordNLPProcessor(PackProcessor):
     def set_up(self):
         self.processors = dict(self.configs.processors)
         stanza.download(
-            self.configs.lang,
-            self.configs.dir,
-            processors=self.processors
-            )
+            self.configs.lang, self.configs.dir, processors=self.processors
+        )
 
     # pylint: disable=unused-argument
     def initialize(self, resources: Resources, configs: Config):
@@ -72,12 +68,12 @@ class StandfordNLPProcessor(PackProcessor):
         """
         return {
             # "processors": "tokenize,pos,lemma,depparse,ner",
-            "processors":{
-               'tokenize':'default',
-               'pos':'defualt',
-               'lemma':'default',
-               'depparse':'default',
-               'ner':'i2b2'
+            "processors": {
+                "tokenize": "default",
+                "pos": "defualt",
+                "lemma": "default",
+                "depparse": "default",
+                "ner": "i2b2",
             },
             "lang": "en",
             # Language code for the language to build the Pipeline
@@ -148,10 +144,8 @@ class StandfordNLPProcessor(PackProcessor):
                 # Iterating through all entities
                 for ent in sentence.entities:
                     entity = EntityMention(
-                        input_pack,
-                        ent.start_char,
-                        ent.end_char
-                        )
+                        input_pack, ent.start_char, ent.end_char
+                    )
                     entity.ner_type = ent.type
 
     def record(self, record_meta: Dict[str, Set[str]]):
@@ -170,10 +164,8 @@ class StandfordNLPProcessor(PackProcessor):
             if "lemma" in self.processors:
                 record_meta["ft.onto.base_ontology.Token"].add("lemma")
             if "depparse" in self.configs.processors:
-                record_meta["ft.onto.base_ontology.Dependency"] = {
-                    "rel_type"
-                    }
+                record_meta["ft.onto.base_ontology.Dependency"] = {"rel_type"}
             if "ner" in self.configs.processors:
                 record_meta["ft.onto.base_ontology.EntityMention"] = {
                     "ner_type"
-                    }
+                }

--- a/src/stanza/fortex/stanza/stanza_processor.py
+++ b/src/stanza/fortex/stanza/stanza_processor.py
@@ -33,12 +33,15 @@ class StandfordNLPProcessor(PackProcessor):
     def __init__(self):
         super().__init__()
         self.nlp = None
-        self.processors = dict()
+        self.processors = {}
 
     def set_up(self):
         self.processors = dict(self.configs.processors)
-        stanza.download(self.configs.lang, self.configs.dir, processors = self.processors)
-        
+        stanza.download(
+            self.configs.lang,
+            self.configs.dir,
+            processors=self.processors
+            )
 
     # pylint: disable=unused-argument
     def initialize(self, resources: Resources, configs: Config):
@@ -61,7 +64,6 @@ class StandfordNLPProcessor(PackProcessor):
             use_gpu=self.configs.use_gpu,
             processors=self.processors,
         )
-        
 
     @classmethod
     def default_configs(cls) -> Dict[str, Any]:
@@ -140,12 +142,16 @@ class StandfordNLPProcessor(PackProcessor):
                     parent = tokens[word.head - 1]  # Head token
                     relation_entry = Dependency(input_pack, parent, child)
                     relation_entry.rel_type = word.deprel
-            
+
             # For each sentence, get the entity mentions
             if "ner" in self.processors:
                 # Iterating through all entities
                 for ent in sentence.entities:
-                    entity = EntityMention(input_pack, ent.start_char, ent.end_char)
+                    entity = EntityMention(
+                        input_pack,
+                        ent.start_char,
+                        ent.end_char
+                        )
                     entity.ner_type = ent.type
 
     def record(self, record_meta: Dict[str, Set[str]]):
@@ -164,6 +170,10 @@ class StandfordNLPProcessor(PackProcessor):
             if "lemma" in self.processors:
                 record_meta["ft.onto.base_ontology.Token"].add("lemma")
             if "depparse" in self.configs.processors:
-                record_meta["ft.onto.base_ontology.Dependency"] = {"rel_type"}
+                record_meta["ft.onto.base_ontology.Dependency"] = {
+                    "rel_type"
+                    }
             if "ner" in self.configs.processors:
-                record_meta["ft.onto.base_ontology.EntityMention"] = {"ner_type"}
+                record_meta["ft.onto.base_ontology.EntityMention"] = {
+                    "ner_type"
+                    }

--- a/tests/wrappers/stanfordnlp_processor_test.py
+++ b/tests/wrappers/stanfordnlp_processor_test.py
@@ -94,14 +94,14 @@ class TestStanfordNLPProcessor(unittest.TestCase):
 
         entities_entries = list(pack.get(entry_type=EntityMention))
 
-        texts = ['Forte', 'NLP']
-        types = ['ORG','ORG']
+        target_texts = ['Forte', 'NLP']
+        target_types = ['ORG','ORG']
         entities_text = [x.text for x in entities_entries]
         entities_type = [x.ner_type for x in entities_entries]
 
         # ner assertation
-        self.assertEqual(entities_text, texts)
-        self.assertEqual(entities_type, types)
+        self.assertEqual(entities_text, target_texts)
+        self.assertEqual(entities_type, target_types)
 
         
 class TestStanfordBioNERProcessor(unittest.TestCase):

--- a/tests/wrappers/stanfordnlp_processor_test.py
+++ b/tests/wrappers/stanfordnlp_processor_test.py
@@ -17,18 +17,22 @@ Unit tests for Stanford NLP processors.
 import imp
 import os
 import unittest
+from typing import List
 
+from ddt import ddt, data
 from forte.data.data_pack import DataPack
 from forte.pipeline import Pipeline
 from forte.data.readers import StringReader
 from fortex.stanza import StandfordNLPProcessor
-from ft.onto.base_ontology import Token, Sentence, EntityMention
+from ft.onto.base_ontology import Token, Sentence, EntityMention, Dependency
 
-
+@ddt
 class TestStanfordNLPProcessor(unittest.TestCase):
-    def setUp(self):
-        self.stanford_nlp = Pipeline[DataPack]()
-        self.stanford_nlp.set_reader(StringReader())
+
+    def test_stanford_processing(self):
+        pipeline = Pipeline[DataPack]()
+        pipeline.set_reader(StringReader())
+
         config = {
             "processors":{
                "tokenize":"default",
@@ -41,86 +45,164 @@ class TestStanfordNLPProcessor(unittest.TestCase):
             # Language code for the language to build the Pipeline
             "use_gpu": False,
         }
-        self.stanford_nlp.add(StandfordNLPProcessor(), config=config)
-        self.stanford_nlp.initialize()
 
-    def test_stanford_processing(self):
+        pipeline.add(StandfordNLPProcessor(), config=config)
+        pipeline.initialize()
+
         sentences = [
             "This tool is called Forte.",
             "The goal of this project to help you build NLP " "pipelines.",
-            "NLP has never been made this easy before."
-        ]
-        document = " ".join(sentences)
-        pack = self.stanford_nlp.process(document)
-
-        for idx, sentence in enumerate(pack.get(Sentence)):
-            # sentence assertation
-            self.assertEqual(sentence.text, sentences[idx])
-        
-        tokens = [
-            ["This", "tool", "is", "called", "Forte", "."],
-            [
-                "The",
-                "goal",
-                "of",
-                "this",
-                "project",
-                "to",
-                "help",
-                "you",
-                "build",
-                "NLP",
-                "pipelines",
-                "."
-            ],
-            [
-                "NLP",
-                "has",
-                "never",
-                "been",
-                "made",
-                "this",
-                "easy",
-                "before",
-                "."
-            ],
-        ]
-
-        pos = [['DET', 'NOUN', 'AUX', 'VERB', 'PROPN', 'PUNCT'], 
-        ['DET', 'NOUN', 'ADP', 'DET', 'NOUN', 'PART', 'VERB', 'PRON', 'VERB', 'NOUN', 'NOUN', 'PUNCT'], 
-        ['NOUN', 'AUX', 'ADV', 'AUX', 'VERB', 'PRON', 'ADJ', 'ADV', 'PUNCT']]
-
-        for i, sentence in enumerate(pack.get(Sentence)):
-            for j, token in enumerate(
-                pack.get(entry_type=Token, range_annotation=sentence)
-            ):
-                # token/pos assertation
-                self.assertEqual(token.text, tokens[i][j])
-                self.assertEqual(token.pos, pos[i][j])
-
-        sentences = [
+            "NLP has never been made this easy before.",
             "I lived in New York.",
             "Yesterday my stomach ached violently.",
             "I think it may be appendicitis or gastroenteritis.",
             "Also it may be the acute pancreatitis.",
-            "Is this Forte?"
         ]
+
         document = " ".join(sentences)
+        pack = pipeline.process(document)
 
-        pack = self.stanford_nlp.process(document)
+        # Check document
+        self.assertEqual(pack.text, document)
 
-        entities_entries = list(pack.get(entry_type=EntityMention))
+        # Check tokens
+        tokens = [x.text for x in pack.get(Token)]
+        document = document.replace(".", " .")
+        self.assertEqual(tokens, document.split())
+    
+    @data(
+        {
+            "tokenize":"default",
+            "pos":"defualt",
+            "lemma":"default",
+            "depparse":"default",
+            "ner":"default"
+        }, # all the configurations are set as defualt
+        {
+            "tokenize":"default",
+            "pos":"defualt",
+            "lemma":"default",
+            "depparse":"default",
+            "ner":"i2b2"            
+        }, # get bio ner
+        {
+            "ner":"i2b2"
+        }, # test with ner only
+        # {
+        #     "tokenize":"mimic",
+        #     "pos":"mimic",
+        #     "lemma":"mimic",
+        #     "depparse":"mimic",
+        #     "ner":"i2b2"             
+        # } # test pipelie all based on mimic model
+    )
+    def test_stanza_pipeline(self, value):
+        pipeline = Pipeline[DataPack]()
+        pipeline.set_reader(StringReader())
 
-        target_texts = ['appendicitis', 'gastroenteritis', 'the acute pancreatitis']
-        target_types = ['PROBLEM', 'PROBLEM', 'PROBLEM']
+        config = {
+            "processors": value,
+            "lang": "en",
+            # Language code for the language to build the Pipeline
+            "use_gpu": False,
+        }
 
-        entities_text = [x.text for x in entities_entries]
-        entities_type = [x.ner_type for x in entities_entries]
+        pipeline.add(StandfordNLPProcessor(), config=config)
+        pipeline.initialize()
 
-        # bio ner assertation
-        self.assertEqual(entities_text, target_texts)
-        self.assertEqual(entities_type, target_types)
+        sentences = [
+            "This tool is called Forte.",
+            "The goal of this project to help you build NLP " "pipelines.",
+            "NLP has never been made this easy before.",
+            "I lived in New York.",
+            "Yesterday my stomach ached violently.",
+            "I think it may be appendicitis or gastroenteritis.",
+            "Also it may be the acute pancreatitis.",
+        ]
 
+        document = " ".join(sentences)
+        pack = pipeline.process(document)
 
+        forte_tokens: List[Token] = list(pack.get(Token))  # type: ignore
+
+        if "tokenize" in value:
+            # Check tokenization
+            tokens_text = [x.text for x in forte_tokens]
+            self.assertEqual(
+                tokens_text, pack.text.replace(".", " .").split()
+            )
+
+            # Check Part-of-Speech Tagger
+            if "pos" in value:
+                pos = [x.pos for x in forte_tokens]
+                exp_pos = [
+                    'DET', 'NOUN', 'AUX', 'VERB', 'PROPN', 'PUNCT', 
+                    'DET', 'NOUN', 'ADP', 'DET', 'NOUN', 'PART', 'VERB', 'PRON', 'VERB', 'NOUN', 'NOUN', 'PUNCT', 
+                    'NOUN', 'AUX', 'ADV', 'AUX', 'VERB', 'PRON', 'ADJ', 'ADV', 'PUNCT', 
+                    'PRON', 'VERB', 'ADP', 'PROPN', 'PROPN', 'PUNCT', 
+                    'NOUN', 'PRON', 'NOUN', 'VERB', 'ADV', 'PUNCT', 
+                    'PRON', 'VERB', 'PRON', 'AUX', 'AUX', 'NOUN', 'CCONJ', 'NOUN', 'PUNCT', 
+                    'ADV', 'PRON', 'AUX', 'AUX', 'DET', 'ADJ', 'NOUN', 'PUNCT'
+                    ]
+                self.assertListEqual(pos, exp_pos)
+            
+            # check lemmatization
+            if "lemma" in value:
+                lemma = [x.lemma for x in forte_tokens]
+                exp_lemma = [
+                    'this', 'tool', 'be', 'call', 'Forte', '.', 
+                    'the', 'goal', 'of', 'this', 'project', 'to', 'help', 'you', 'build', 'nlp', 'pipeline', '.', 
+                    'nlp', 'have', 'never', 'be', 'make', 'this', 'easy', 'before', '.', 
+                    'I', 'live', 'in', 'New', 'York', '.', 
+                    'yesterday', 'my', 'stomach', 'ach', 'violently', '.', 
+                    'I', 'think', 'it', 'may', 'be', 'appendicitis', 'or', 'gastroenteritis', '.', 
+                    'also', 'it', 'may', 'be', 'the', 'acute', 'pancreatitis', '.'
+                    ]
+                self.assertListEqual(lemma, exp_lemma)
+            
+            # Check dependency parsing
+            if "depparse" in value:
+                dependencies = [
+                (dep.get_parent().text, dep.get_child().text, dep.rel_type)
+                for dep in pack.get(Dependency)
+                ]
+                exp_dependencies = [
+                    ('tool', 'This', 'det'), ('called', 'tool', 'nsubj:pass'), ('called', 'is', 'aux:pass'), ('.', 'called', 'root'), ('called', 'Forte', 'xcomp'), ('called', '.', 'punct'), 
+                    ('goal', 'The', 'det'), ('.', 'goal', 'root'), ('project', 'of', 'case'), ('project', 'this', 'det'), ('goal', 'project', 'nmod'), ('help', 'to', 'mark'), ('goal', 'help', 'acl'), ('help', 'you', 'obj'), ('help', 'build', 'xcomp'), ('pipelines', 'NLP', 'compound'), ('build', 'pipelines', 'obj'), ('goal', '.', 'punct'), 
+                    ('made', 'NLP', 'nsubj:pass'), ('made', 'has', 'aux'), ('made', 'never', 'advmod'), ('made', 'been', 'aux:pass'), ('.', 'made', 'root'), ('made', 'this', 'obj'), ('made', 'easy', 'xcomp'), ('made', 'before', 'advmod'), ('made', '.', 'punct'), 
+                    ('lived', 'I', 'nsubj'), ('.', 'lived', 'root'), ('York', 'in', 'case'), ('York', 'New', 'compound'), ('lived', 'York', 'obl'), ('lived', '.', 'punct'), 
+                    ('ached', 'Yesterday', 'obl:tmod'), ('stomach', 'my', 'nmod:poss'), ('ached', 'stomach', 'nsubj'), ('.', 'ached', 'root'), ('ached', 'violently', 'advmod'), ('ached', '.', 'punct'), 
+                    ('think', 'I', 'nsubj'), ('.', 'think', 'root'), ('appendicitis', 'it', 'nsubj'), ('appendicitis', 'may', 'aux'), ('appendicitis', 'be', 'cop'), ('think', 'appendicitis', 'ccomp'), ('gastroenteritis', 'or', 'cc'), ('appendicitis', 'gastroenteritis', 'conj'), ('think', '.', 'punct'), 
+                    ('pancreatitis', 'Also', 'advmod'), ('pancreatitis', 'it', 'nsubj'), ('pancreatitis', 'may', 'aux'), ('pancreatitis', 'be', 'cop'), ('pancreatitis', 'the', 'det'), ('pancreatitis', 'acute', 'amod'), ('.', 'pancreatitis', 'root'), ('pancreatitis', '.', 'punct')
+                    ]               
+                self.assertListEqual(dependencies, exp_dependencies)
+        
+        # Check Bio NER
+        if "ner" in value and value["ner"] == "i2b2":
+            pack_ents: List[EntityMention] = list(pack.get(EntityMention))
+
+            entities_text = [x.text for x in pack_ents]
+            entities_type = [x.ner_type for x in pack_ents]
+
+            exp_entities_text = ['appendicitis', 'gastroenteritis', 'the acute pancreatitis']
+            exp_entities_type = ['PROBLEM', 'PROBLEM', 'PROBLEM']
+
+            self.assertEqual(entities_text, exp_entities_text)
+            self.assertEqual(entities_type, exp_entities_type)
+        
+        # Chech NER
+        if "ner" in value and value["ner"] != "i2b2":
+            pack_ents: List[EntityMention] = list(pack.get(EntityMention))
+
+            entities_text = [x.text for x in pack_ents]
+            entities_type = [x.ner_type for x in pack_ents]
+
+            exp_entities_text = ['Forte', 'NLP', 'New York', 'Yesterday']
+            exp_entities_type = ['ORG', 'ORG', 'GPE', 'DATE']
+
+            self.assertEqual(entities_text, exp_entities_text)
+            self.assertEqual(entities_type, exp_entities_type)    
+
+            
 if __name__ == "__main__":
     unittest.main()

--- a/tests/wrappers/stanfordnlp_processor_test.py
+++ b/tests/wrappers/stanfordnlp_processor_test.py
@@ -96,6 +96,7 @@ class TestStanfordNLPProcessor(unittest.TestCase):
 
         target_texts = ['Forte', 'NLP']
         target_types = ['ORG','ORG']
+
         entities_text = [x.text for x in entities_entries]
         entities_type = [x.ner_type for x in entities_entries]
 
@@ -121,7 +122,6 @@ class TestStanfordBioNERProcessor(unittest.TestCase):
         ]
         document = " ".join(sentences)
 
-        print(document)
         pack = self.stanford_nlp.process(document)
 
         for idx, sentence in enumerate(pack.get(Sentence)):
@@ -132,9 +132,11 @@ class TestStanfordBioNERProcessor(unittest.TestCase):
 
         target_texts = ['appendicitis', 'gastroenteritis', 'the acute pancreatitis']
         target_types = ['PROBLEM', 'PROBLEM', 'PROBLEM']
+
         entities_text = [x.text for x in entities_entries]
         entities_type = [x.ner_type for x in entities_entries]
 
+        # bio ner assertation
         self.assertEqual(entities_text, target_texts)
         self.assertEqual(entities_type, target_types)
 

--- a/tests/wrappers/stanfordnlp_processor_test.py
+++ b/tests/wrappers/stanfordnlp_processor_test.py
@@ -14,13 +14,14 @@
 """
 Unit tests for Stanford NLP processors.
 """
+import imp
 import os
 import unittest
 
 from forte.data.data_pack import DataPack
 from forte.pipeline import Pipeline
 from forte.data.readers import StringReader
-from fortex.stanza import StandfordNLPProcessor, StanfordNLPBioNERProcessor
+from fortex.stanza import StandfordNLPProcessor
 from ft.onto.base_ontology import Token, Sentence, EntityMention
 
 
@@ -29,7 +30,13 @@ class TestStanfordNLPProcessor(unittest.TestCase):
         self.stanford_nlp = Pipeline[DataPack]()
         self.stanford_nlp.set_reader(StringReader())
         config = {
-            "processors": "tokenize,pos,lemma,depparse,ner",
+            "processors":{
+               "tokenize":"default",
+               "pos":"defualt",
+               "lemma":"default",
+               "depparse":"default",
+               "ner":"i2b2"
+            },
             "lang": "en",
             # Language code for the language to build the Pipeline
             "use_gpu": False,
@@ -42,7 +49,6 @@ class TestStanfordNLPProcessor(unittest.TestCase):
             "This tool is called Forte.",
             "The goal of this project to help you build NLP " "pipelines.",
             "NLP has never been made this easy before."
-            # "I have to say I am suffering headache and acutebronchitis."
         ]
         document = " ".join(sentences)
         pack = self.stanford_nlp.process(document)
@@ -92,27 +98,6 @@ class TestStanfordNLPProcessor(unittest.TestCase):
                 self.assertEqual(token.text, tokens[i][j])
                 self.assertEqual(token.pos, pos[i][j])
 
-        entities_entries = list(pack.get(entry_type=EntityMention))
-
-        target_texts = ['Forte', 'NLP']
-        target_types = ['ORG','ORG']
-
-        entities_text = [x.text for x in entities_entries]
-        entities_type = [x.ner_type for x in entities_entries]
-
-        # ner assertation
-        self.assertEqual(entities_text, target_texts)
-        self.assertEqual(entities_type, target_types)
-
-        
-class TestStanfordBioNERProcessor(unittest.TestCase):
-    def setUp(self):
-        self.stanford_nlp = Pipeline[DataPack]()
-        self.stanford_nlp.set_reader(StringReader())
-        self.stanford_nlp.add(StanfordNLPBioNERProcessor())
-        self.stanford_nlp.initialize()
-
-    def test_stanford_processing(self):
         sentences = [
             "I lived in New York.",
             "Yesterday my stomach ached violently.",
@@ -124,10 +109,6 @@ class TestStanfordBioNERProcessor(unittest.TestCase):
 
         pack = self.stanford_nlp.process(document)
 
-        for idx, sentence in enumerate(pack.get(Sentence)):
-            # sentence assertation
-            self.assertEqual(sentence.text, sentences[idx])
-        
         entities_entries = list(pack.get(entry_type=EntityMention))
 
         target_texts = ['appendicitis', 'gastroenteritis', 'the acute pancreatitis']

--- a/tests/wrappers/stanfordnlp_processor_test.py
+++ b/tests/wrappers/stanfordnlp_processor_test.py
@@ -20,7 +20,8 @@ import unittest
 from forte.data.data_pack import DataPack
 from forte.pipeline import Pipeline
 from forte.data.readers import StringReader
-from fortex.stanza import StandfordNLPProcessor
+from fortex.stanza import StandfordNLPProcessor, StanfordNLPBioNERProcessor
+from ft.onto.base_ontology import Token, Sentence, EntityMention
 
 
 class TestStanfordNLPProcessor(unittest.TestCase):
@@ -28,7 +29,7 @@ class TestStanfordNLPProcessor(unittest.TestCase):
         self.stanford_nlp = Pipeline[DataPack]()
         self.stanford_nlp.set_reader(StringReader())
         config = {
-            "processors": "tokenize",
+            "processors": "tokenize,pos,lemma,depparse,ner",
             "lang": "en",
             # Language code for the language to build the Pipeline
             "use_gpu": False,
@@ -36,14 +37,106 @@ class TestStanfordNLPProcessor(unittest.TestCase):
         self.stanford_nlp.add(StandfordNLPProcessor(), config=config)
         self.stanford_nlp.initialize()
 
-    def test_stanford_processor(self):
+    def test_stanford_processing(self):
         sentences = [
             "This tool is called Forte.",
             "The goal of this project to help you build NLP " "pipelines.",
-            "NLP has never been made this easy before.",
+            "NLP has never been made this easy before."
+            # "I have to say I am suffering headache and acutebronchitis."
         ]
         document = " ".join(sentences)
-        self.stanford_nlp.process(document)
+        pack = self.stanford_nlp.process(document)
+
+        for idx, sentence in enumerate(pack.get(Sentence)):
+            # sentence assertation
+            self.assertEqual(sentence.text, sentences[idx])
+        
+        tokens = [
+            ["This", "tool", "is", "called", "Forte", "."],
+            [
+                "The",
+                "goal",
+                "of",
+                "this",
+                "project",
+                "to",
+                "help",
+                "you",
+                "build",
+                "NLP",
+                "pipelines",
+                "."
+            ],
+            [
+                "NLP",
+                "has",
+                "never",
+                "been",
+                "made",
+                "this",
+                "easy",
+                "before",
+                "."
+            ],
+        ]
+
+        pos = [['DET', 'NOUN', 'AUX', 'VERB', 'PROPN', 'PUNCT'], 
+        ['DET', 'NOUN', 'ADP', 'DET', 'NOUN', 'PART', 'VERB', 'PRON', 'VERB', 'NOUN', 'NOUN', 'PUNCT'], 
+        ['NOUN', 'AUX', 'ADV', 'AUX', 'VERB', 'PRON', 'ADJ', 'ADV', 'PUNCT']]
+
+        for i, sentence in enumerate(pack.get(Sentence)):
+            for j, token in enumerate(
+                pack.get(entry_type=Token, range_annotation=sentence)
+            ):
+                # token/pos assertation
+                self.assertEqual(token.text, tokens[i][j])
+                self.assertEqual(token.pos, pos[i][j])
+
+        entities_entries = list(pack.get(entry_type=EntityMention))
+
+        texts = ['Forte', 'NLP']
+        types = ['ORG','ORG']
+        entities_text = [x.text for x in entities_entries]
+        entities_type = [x.ner_type for x in entities_entries]
+
+        # ner assertation
+        self.assertEqual(entities_text, texts)
+        self.assertEqual(entities_type, types)
+
+        
+class TestStanfordBioNERProcessor(unittest.TestCase):
+    def setUp(self):
+        self.stanford_nlp = Pipeline[DataPack]()
+        self.stanford_nlp.set_reader(StringReader())
+        self.stanford_nlp.add(StanfordNLPBioNERProcessor())
+        self.stanford_nlp.initialize()
+
+    def test_stanford_processing(self):
+        sentences = [
+            "I lived in New York.",
+            "Yesterday my stomach ached violently.",
+            "I think it may be appendicitis or gastroenteritis.",
+            "Also it may be the acute pancreatitis.",
+            "Is this Forte?"
+        ]
+        document = " ".join(sentences)
+
+        print(document)
+        pack = self.stanford_nlp.process(document)
+
+        for idx, sentence in enumerate(pack.get(Sentence)):
+            # sentence assertation
+            self.assertEqual(sentence.text, sentences[idx])
+        
+        entities_entries = list(pack.get(entry_type=EntityMention))
+
+        target_texts = ['appendicitis', 'gastroenteritis', 'the acute pancreatitis']
+        target_types = ['PROBLEM', 'PROBLEM', 'PROBLEM']
+        entities_text = [x.text for x in entities_entries]
+        entities_type = [x.ner_type for x in entities_entries]
+
+        self.assertEqual(entities_text, target_texts)
+        self.assertEqual(entities_type, target_types)
 
 
 if __name__ == "__main__":

--- a/tests/wrappers/stanfordnlp_processor_test.py
+++ b/tests/wrappers/stanfordnlp_processor_test.py
@@ -26,6 +26,7 @@ from forte.data.readers import StringReader
 from fortex.stanza import StandfordNLPProcessor
 from ft.onto.base_ontology import Token, Sentence, EntityMention, Dependency
 
+
 @ddt
 class TestStanfordNLPProcessor(unittest.TestCase):
 
@@ -69,7 +70,7 @@ class TestStanfordNLPProcessor(unittest.TestCase):
         tokens = [x.text for x in pack.get(Token)]
         document = document.replace(".", " .")
         self.assertEqual(tokens, document.split())
-    
+
     @data(
         {
             "tokenize":"default",
@@ -77,23 +78,23 @@ class TestStanfordNLPProcessor(unittest.TestCase):
             "lemma":"default",
             "depparse":"default",
             "ner":"default"
-        }, # all the configurations are set as defualt
+        },  # all the configurations are set as defualt
         {
             "tokenize":"default",
             "pos":"defualt",
             "lemma":"default",
             "depparse":"default",
-            "ner":"i2b2"            
-        }, # get bio ner
+            "ner":"i2b2"
+        },  # get bio ner
         {
             "ner":"i2b2"
-        }, # test with ner only
+        },  # test with ner only
         # {
         #     "tokenize":"mimic",
         #     "pos":"mimic",
         #     "lemma":"mimic",
         #     "depparse":"mimic",
-        #     "ner":"i2b2"             
+        #     "ner":"i2b2"
         # } # test pipelie all based on mimic model
     )
     def test_stanza_pipeline(self, value):
@@ -136,30 +137,30 @@ class TestStanfordNLPProcessor(unittest.TestCase):
             if "pos" in value:
                 pos = [x.pos for x in forte_tokens]
                 exp_pos = [
-                    'DET', 'NOUN', 'AUX', 'VERB', 'PROPN', 'PUNCT', 
-                    'DET', 'NOUN', 'ADP', 'DET', 'NOUN', 'PART', 'VERB', 'PRON', 'VERB', 'NOUN', 'NOUN', 'PUNCT', 
-                    'NOUN', 'AUX', 'ADV', 'AUX', 'VERB', 'PRON', 'ADJ', 'ADV', 'PUNCT', 
-                    'PRON', 'VERB', 'ADP', 'PROPN', 'PROPN', 'PUNCT', 
-                    'NOUN', 'PRON', 'NOUN', 'VERB', 'ADV', 'PUNCT', 
-                    'PRON', 'VERB', 'PRON', 'AUX', 'AUX', 'NOUN', 'CCONJ', 'NOUN', 'PUNCT', 
+                    'DET', 'NOUN', 'AUX', 'VERB', 'PROPN', 'PUNCT',
+                    'DET', 'NOUN', 'ADP', 'DET', 'NOUN', 'PART', 'VERB', 'PRON', 'VERB', 'NOUN', 'NOUN', 'PUNCT',
+                    'NOUN', 'AUX', 'ADV', 'AUX', 'VERB', 'PRON', 'ADJ', 'ADV', 'PUNCT',
+                    'PRON', 'VERB', 'ADP', 'PROPN', 'PROPN', 'PUNCT',
+                    'NOUN', 'PRON', 'NOUN', 'VERB', 'ADV', 'PUNCT',
+                    'PRON', 'VERB', 'PRON', 'AUX', 'AUX', 'NOUN', 'CCONJ', 'NOUN', 'PUNCT',
                     'ADV', 'PRON', 'AUX', 'AUX', 'DET', 'ADJ', 'NOUN', 'PUNCT'
                     ]
                 self.assertListEqual(pos, exp_pos)
-            
+
             # check lemmatization
             if "lemma" in value:
                 lemma = [x.lemma for x in forte_tokens]
                 exp_lemma = [
-                    'this', 'tool', 'be', 'call', 'Forte', '.', 
-                    'the', 'goal', 'of', 'this', 'project', 'to', 'help', 'you', 'build', 'nlp', 'pipeline', '.', 
-                    'nlp', 'have', 'never', 'be', 'make', 'this', 'easy', 'before', '.', 
-                    'I', 'live', 'in', 'New', 'York', '.', 
-                    'yesterday', 'my', 'stomach', 'ach', 'violently', '.', 
-                    'I', 'think', 'it', 'may', 'be', 'appendicitis', 'or', 'gastroenteritis', '.', 
+                    'this', 'tool', 'be', 'call', 'Forte', '.',
+                    'the', 'goal', 'of', 'this', 'project', 'to', 'help', 'you', 'build', 'nlp', 'pipeline', '.',
+                    'nlp', 'have', 'never', 'be', 'make', 'this', 'easy', 'before', '.',
+                    'I', 'live', 'in', 'New', 'York', '.',
+                    'yesterday', 'my', 'stomach', 'ach', 'violently', '.',
+                    'I', 'think', 'it', 'may', 'be', 'appendicitis', 'or', 'gastroenteritis', '.',
                     'also', 'it', 'may', 'be', 'the', 'acute', 'pancreatitis', '.'
                     ]
                 self.assertListEqual(lemma, exp_lemma)
-            
+
             # Check dependency parsing
             if "depparse" in value:
                 dependencies = [
@@ -167,16 +168,16 @@ class TestStanfordNLPProcessor(unittest.TestCase):
                 for dep in pack.get(Dependency)
                 ]
                 exp_dependencies = [
-                    ('tool', 'This', 'det'), ('called', 'tool', 'nsubj:pass'), ('called', 'is', 'aux:pass'), ('.', 'called', 'root'), ('called', 'Forte', 'xcomp'), ('called', '.', 'punct'), 
-                    ('goal', 'The', 'det'), ('.', 'goal', 'root'), ('project', 'of', 'case'), ('project', 'this', 'det'), ('goal', 'project', 'nmod'), ('help', 'to', 'mark'), ('goal', 'help', 'acl'), ('help', 'you', 'obj'), ('help', 'build', 'xcomp'), ('pipelines', 'NLP', 'compound'), ('build', 'pipelines', 'obj'), ('goal', '.', 'punct'), 
-                    ('made', 'NLP', 'nsubj:pass'), ('made', 'has', 'aux'), ('made', 'never', 'advmod'), ('made', 'been', 'aux:pass'), ('.', 'made', 'root'), ('made', 'this', 'obj'), ('made', 'easy', 'xcomp'), ('made', 'before', 'advmod'), ('made', '.', 'punct'), 
-                    ('lived', 'I', 'nsubj'), ('.', 'lived', 'root'), ('York', 'in', 'case'), ('York', 'New', 'compound'), ('lived', 'York', 'obl'), ('lived', '.', 'punct'), 
-                    ('ached', 'Yesterday', 'obl:tmod'), ('stomach', 'my', 'nmod:poss'), ('ached', 'stomach', 'nsubj'), ('.', 'ached', 'root'), ('ached', 'violently', 'advmod'), ('ached', '.', 'punct'), 
-                    ('think', 'I', 'nsubj'), ('.', 'think', 'root'), ('appendicitis', 'it', 'nsubj'), ('appendicitis', 'may', 'aux'), ('appendicitis', 'be', 'cop'), ('think', 'appendicitis', 'ccomp'), ('gastroenteritis', 'or', 'cc'), ('appendicitis', 'gastroenteritis', 'conj'), ('think', '.', 'punct'), 
+                    ('tool', 'This', 'det'), ('called', 'tool', 'nsubj:pass'), ('called', 'is', 'aux:pass'), ('.', 'called', 'root'), ('called', 'Forte', 'xcomp'), ('called', '.', 'punct'),
+                    ('goal', 'The', 'det'), ('.', 'goal', 'root'), ('project', 'of', 'case'), ('project', 'this', 'det'), ('goal', 'project', 'nmod'), ('help', 'to', 'mark'), ('goal', 'help', 'acl'), ('help', 'you', 'obj'), ('help', 'build', 'xcomp'), ('pipelines', 'NLP', 'compound'), ('build', 'pipelines', 'obj'), ('goal', '.', 'punct'),
+                    ('made', 'NLP', 'nsubj:pass'), ('made', 'has', 'aux'), ('made', 'never', 'advmod'), ('made', 'been', 'aux:pass'), ('.', 'made', 'root'), ('made', 'this', 'obj'), ('made', 'easy', 'xcomp'), ('made', 'before', 'advmod'), ('made', '.', 'punct'),
+                    ('lived', 'I', 'nsubj'), ('.', 'lived', 'root'), ('York', 'in', 'case'), ('York', 'New', 'compound'), ('lived', 'York', 'obl'), ('lived', '.', 'punct'),
+                    ('ached', 'Yesterday', 'obl:tmod'), ('stomach', 'my', 'nmod:poss'), ('ached', 'stomach', 'nsubj'), ('.', 'ached', 'root'), ('ached', 'violently', 'advmod'), ('ached', '.', 'punct'),
+                    ('think', 'I', 'nsubj'), ('.', 'think', 'root'), ('appendicitis', 'it', 'nsubj'), ('appendicitis', 'may', 'aux'), ('appendicitis', 'be', 'cop'), ('think', 'appendicitis', 'ccomp'), ('gastroenteritis', 'or', 'cc'), ('appendicitis', 'gastroenteritis', 'conj'), ('think', '.', 'punct'),
                     ('pancreatitis', 'Also', 'advmod'), ('pancreatitis', 'it', 'nsubj'), ('pancreatitis', 'may', 'aux'), ('pancreatitis', 'be', 'cop'), ('pancreatitis', 'the', 'det'), ('pancreatitis', 'acute', 'amod'), ('.', 'pancreatitis', 'root'), ('pancreatitis', '.', 'punct')
-                    ]               
+                    ]
                 self.assertListEqual(dependencies, exp_dependencies)
-        
+
         # Check Bio NER
         if "ner" in value and value["ner"] == "i2b2":
             pack_ents: List[EntityMention] = list(pack.get(EntityMention))
@@ -189,7 +190,7 @@ class TestStanfordNLPProcessor(unittest.TestCase):
 
             self.assertEqual(entities_text, exp_entities_text)
             self.assertEqual(entities_type, exp_entities_type)
-        
+
         # Chech NER
         if "ner" in value and value["ner"] != "i2b2":
             pack_ents: List[EntityMention] = list(pack.get(EntityMention))
@@ -201,8 +202,8 @@ class TestStanfordNLPProcessor(unittest.TestCase):
             exp_entities_type = ['ORG', 'ORG', 'GPE', 'DATE']
 
             self.assertEqual(entities_text, exp_entities_text)
-            self.assertEqual(entities_type, exp_entities_type)    
+            self.assertEqual(entities_type, exp_entities_type)
 
-            
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes asyml/ForteHealth/issues/19.

### Description of changes
I add NER configuration in stanza processor
with the following configuration:
`
config = {
  "processors":{
       "tokenize":"default",
       "pos":"defualt",
       "lemma":"default",
       "depparse":"default",
       "ner":"i2b2"
        },
  "lang": "en",
  "use_gpu": False,
}
`
You can get biological/ medical/ clinical EntityMention of your input data. (This is BioNER)

Also, you can feel free to change the model in the configuration, 
for example, with the following  configuration:
`
config = {
  "processors":{
       "tokenize":"default",
       "pos":"defualt",
       "lemma":"default",
       "depparse":"default",
       "ner":"ontonotes"
        },
  "lang": "en",
  "use_gpu": False,
}
`
You can get basic EntityMention of your input data. (This is NER) 

### Possible influences of this PR.
Support basic NER and Bio NER using stanza processor: all you need to do is modify the configuration according to your requirements.

### Test Conducted
All the test data are explicitly described in stanfordnlp_processor_test.py, and the test is successful.